### PR TITLE
Introduce a SimpleDataLayer

### DIFF
--- a/docs/writing-resolvers.md
+++ b/docs/writing-resolvers.md
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 namespace App\Service\DataLayer\Resolvers;
 
-use Enrise\SyliusDataLayerBundle\DataLayer;
+use Enrise\SyliusDataLayerBundle\DatalayerInterface;
 use Enrise\SyliusDataLayerBundle\Resolvers\ResolverInterface;
 
 final class ThankYouResolver implements ResolverInterface
@@ -32,7 +32,7 @@ final class ThankYouResolver implements ResolverInterface
         return $type === 'thank-you';
     }
 
-    public function resolve(array $data): DataLayer
+    public function resolve(array $data): DataLayerInterface
     {
         $order = $data['order'];
 

--- a/src/DataLayer.php
+++ b/src/DataLayer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Enrise\SyliusDataLayerBundle;
 
-final class DataLayer
+final class DataLayer implements DatalayerInterface
 {
     private string $event;
 

--- a/src/DatalayerInterface.php
+++ b/src/DatalayerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enrise\SyliusDataLayerBundle;
+
+interface DatalayerInterface
+{
+    public function toArray(): array;
+    public function toJson(): string;
+}

--- a/src/Resolvers/ResolverInterface.php
+++ b/src/Resolvers/ResolverInterface.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Enrise\SyliusDataLayerBundle\Resolvers;
 
-use Enrise\SyliusDataLayerBundle\DataLayer;
+use Enrise\SyliusDataLayerBundle\DatalayerInterface;
 
 interface ResolverInterface
 {
     public function supports(string $type): bool;
 
-    public function resolve(array $data): DataLayer;
+    public function resolve(array $data): DatalayerInterface;
 }

--- a/src/Resolvers/ResolverManager.php
+++ b/src/Resolvers/ResolverManager.php
@@ -16,7 +16,7 @@ final class ResolverManager
         $this->resolvers = $resolvers;
     }
 
-    public function handle(string $type, array $data = []): DataLayer
+    public function handle(string $type, array $data = []): DataLayerInterface
     {
         $resolver = $this->findSupportedResolver($type);
 

--- a/src/SimpleDataLayer.php
+++ b/src/SimpleDataLayer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enrise\SyliusDataLayerBundle;
+
+final class SimpleDataLayer implements DatalayerInterface
+{
+    private array $data;
+
+    public function __construct(array $data = [])
+    {
+        $this->data = $data;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
This SimpleDataLayer can be used for non-event-based datalayers.

To do this, I also introduced an interface for DataLayer objects.